### PR TITLE
feat: add status orb animations

### DIFF
--- a/packages/frontend/src/components/aura/StatusOrb.module.css
+++ b/packages/frontend/src/components/aura/StatusOrb.module.css
@@ -15,7 +15,7 @@
         0 0 40px rgba(var(--glow-rgb), 0.2),
         inset 0 0 15px rgba(0, 0, 0, 0.5);
     transition: background 0.5s ease, box-shadow 0.5s ease;
-    will-change: transform, opacity;
+    will-change: transform, opacity, box-shadow;
 }
 
 .statusOrb::after {

--- a/packages/frontend/src/components/aura/StatusOrb.module.css
+++ b/packages/frontend/src/components/aura/StatusOrb.module.css
@@ -5,37 +5,104 @@
     height: 200px;
     position: relative;
     border-radius: 50%;
-    background: radial-gradient(circle at 50% 35%, rgba(255, 255, 255, 0.5), transparent 20%),
-    radial-gradient(ellipse at center, #2c3e50 0%, #0a0d1a 100%);
-    box-shadow: 0 0 20px rgba(77, 137, 255, 0.3),
-    0 0 40px rgba(77, 137, 255, 0.2),
-    inset 0 0 15px rgba(0, 0, 0, 0.5);
-    animation: orbBreathe 6s ease-in-out infinite;
-    transition: all 0.5s ease;
+    --orb-color: 44, 62, 80;
+    --glow-rgb: 77, 137, 255;
+    background:
+        radial-gradient(circle at 50% 35%, rgba(255, 255, 255, 0.5), transparent 20%),
+        radial-gradient(ellipse at center, rgb(var(--orb-color)) 0%, #0a0d1a 100%);
+    box-shadow:
+        0 0 20px rgba(var(--glow-rgb), 0.3),
+        0 0 40px rgba(var(--glow-rgb), 0.2),
+        inset 0 0 15px rgba(0, 0, 0, 0.5);
+    transition: background 0.5s ease, box-shadow 0.5s ease;
+    will-change: transform, opacity;
 }
+
 .statusOrb::after {
     content: '';
     position: absolute;
     inset: 0;
     border-radius: 50%;
-    background: radial-gradient(circle at 50% 120%, rgba(77, 137, 255, 0.4), transparent 70%);
+    background: radial-gradient(circle at 50% 120%, rgba(var(--glow-rgb), 0.4), transparent 70%);
     opacity: 0.8;
 }
-.orbActive {
-    animation: orbActivePulse 2s ease-in-out infinite;
-    box-shadow: 0 0 30px rgba(0, 255, 225, 0.7), 0 0 60px rgba(0, 255, 225, 0.5), inset 0 0 20px rgba(0, 0, 0, 0.5);
+
+.orbBreathing {
+    --orb-color: 44, 62, 80;
+    --glow-rgb: 77, 137, 255;
+    animation: breath 6s ease-in-out infinite;
 }
-.orbActive::after {
-    background: radial-gradient(circle at 50% 120%, rgba(0, 255, 225, 0.6), transparent 70%);
+
+.orbHeartbeat {
+    --orb-color: 0, 255, 225;
+    --glow-rgb: 0, 255, 225;
+    animation: heartbeat 2s ease-in-out infinite;
+    box-shadow:
+        0 0 30px rgba(var(--glow-rgb), 0.7),
+        0 0 60px rgba(var(--glow-rgb), 0.5),
+        inset 0 0 20px rgba(0, 0, 0, 0.5);
 }
-.orbDisconnected {
-    background: radial-gradient(ellipse at center, #5e2828 0%, #0a0d1a 100%);
-    animation: orbGlitch 1.5s linear infinite;
-    box-shadow: 0 0 30px rgba(255, 50, 50, 0.7), 0 0 60px rgba(255, 50, 50, 0.5);
+
+.orbGlitch {
+    --orb-color: 94, 40, 40;
+    --glow-rgb: 255, 50, 50;
+    animation: glitch 1.5s linear infinite;
+    background: radial-gradient(ellipse at center, rgb(var(--orb-color)) 0%, #0a0d1a 100%);
+    box-shadow:
+        0 0 30px rgba(var(--glow-rgb), 0.7),
+        0 0 60px rgba(var(--glow-rgb), 0.5);
 }
-.orbDisconnected::after {
-    background: radial-gradient(circle at 50% 120%, rgba(255, 50, 50, 0.6), transparent 70%);
+
+@keyframes breath {
+    0%,
+    100% {
+        transform: scale(0.98);
+    }
+    50% {
+        transform: scale(1);
+    }
 }
-@keyframes orbBreathe { 0%, 100% { transform: scale(0.98); } 50% { transform: scale(1); } }
-@keyframes orbActivePulse { 0%, 100% { transform: scale(1); box-shadow: 0 0 30px rgba(0, 255, 225, 0.6), 0 0 60px rgba(0, 255, 225, 0.4), inset 0 0 20px rgba(0, 0, 0, 0.5); } 50% { transform: scale(1.02); box-shadow: 0 0 40px rgba(0, 255, 225, 0.9), 0 0 80px rgba(0, 255, 225, 0.6), inset 0 0 20px rgba(0, 0, 0, 0.5); } }
-@keyframes orbGlitch { 0%, 100% { transform: translate(0, 0); opacity: 1; } 10% { transform: translate(-2px, 2px); } 20% { transform: translate(2px, -2px); } 30% { transform: translate(-2px, -2px); opacity: 0.8; } 40% { transform: translate(2px, 2px); } 50% { transform: translate(0, 0); opacity: 1; } }
+
+@keyframes heartbeat {
+    0%,
+    100% {
+        transform: scale(1);
+        box-shadow:
+            0 0 30px rgba(var(--glow-rgb), 0.6),
+            0 0 60px rgba(var(--glow-rgb), 0.4),
+            inset 0 0 20px rgba(0, 0, 0, 0.5);
+    }
+    50% {
+        transform: scale(1.02);
+        box-shadow:
+            0 0 40px rgba(var(--glow-rgb), 0.9),
+            0 0 80px rgba(var(--glow-rgb), 0.6),
+            inset 0 0 20px rgba(0, 0, 0, 0.5);
+    }
+}
+
+@keyframes glitch {
+    0%,
+    100% {
+        transform: translate(0, 0);
+        opacity: 1;
+    }
+    10% {
+        transform: translate(-2px, 2px);
+    }
+    20% {
+        transform: translate(2px, -2px);
+    }
+    30% {
+        transform: translate(-2px, -2px);
+        opacity: 0.8;
+    }
+    40% {
+        transform: translate(2px, 2px);
+    }
+    50% {
+        transform: translate(0, 0);
+        opacity: 1;
+    }
+}
+

--- a/packages/frontend/src/components/aura/StatusOrb.tsx
+++ b/packages/frontend/src/components/aura/StatusOrb.tsx
@@ -1,16 +1,20 @@
 // packages/frontend/src/components/aura/StatusOrb.tsx
 import { Box } from '@mantine/core';
 import { useControllerStore } from '../../store/useControllerStore';
-import classes from './StatusOrb.module.css'; // GÜNCELLENDİ
 import cx from 'clsx';
-// ... (geri kalan kod aynı)
+import classes from './StatusOrb.module.css';
+
 export function StatusOrb() {
     const { connectionStatus, arduinoStatus, motor } = useControllerStore();
-    const isDisconnected = connectionStatus === 'disconnected' || arduinoStatus === 'disconnected';
-    const isMotorActive = motor.isActive;
-    const orbClassName = cx(classes.statusOrb, {
-        [classes.orbDisconnected]: isDisconnected,
-        [classes.orbActive]: isMotorActive && !isDisconnected,
-    });
-    return <Box className={orbClassName} />;
+    const isDisconnected =
+        connectionStatus === 'disconnected' || arduinoStatus === 'disconnected';
+
+    let stateClass = classes.orbBreathing;
+    if (isDisconnected) {
+        stateClass = classes.orbGlitch;
+    } else if (motor.isActive) {
+        stateClass = classes.orbHeartbeat;
+    }
+
+    return <Box className={cx(classes.statusOrb, stateClass)} />;
 }


### PR DESCRIPTION
## Summary
- add breath, heartbeat and glitch animations to StatusOrb
- switch orb classes based on motor and connection state

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_6893988383208320a5b863986e0b6943