### PR TITLE
feat: animate aura background with connection and motor state

### DIFF
--- a/packages/frontend/src/components/aura/AuraLayout.module.css
+++ b/packages/frontend/src/components/aura/AuraLayout.module.css
@@ -30,16 +30,86 @@
     transform: translate(-50%, -60%);
 }
 
-/* ... Arka plan stilleri aynı kalıyor ... */
+/* Dynamic background */
 .dynamicBackground {
+    --bg-speed: 1;
+    --bg-brightness: 0.8;
     position: absolute;
-    top: 0; left: 0;
-    width: 100%; height: 100%;
-    z-index: 1; filter: blur(50px);
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    z-index: 1;
+    filter: blur(50px) brightness(var(--bg-brightness));
     background-color: #020308;
+    transition: filter 0.4s ease, background-color 0.4s ease;
 }
-.dynamicBackground::before, .dynamicBackground::after { content: ''; position: absolute; border-radius: 50%; }
-.dynamicBackground::before { width: 400px; height: 400px; background: radial-gradient(circle, rgba(25, 33, 72, 0.8), transparent 70%); animation: move1 20s infinite alternate; }
-.dynamicBackground::after { width: 300px; height: 300px; background: radial-gradient(circle, rgba(56, 33, 99, 0.6), transparent 70%); animation: move2 15s infinite alternate; }
-@keyframes move1 { 0% { transform: translate(10vw, 20vh) scale(1); } 100% { transform: translate(70vw, 80vh) scale(1.5); } }
-@keyframes move2 { 0% { transform: translate(80vw, 10vh) scale(1.2); } 100% { transform: translate(20vw, 60vh) scale(0.9); } }
+
+.dynamicBackground::before,
+.dynamicBackground::after {
+    content: '';
+    position: absolute;
+    border-radius: 50%;
+    transition: background 0.4s ease;
+}
+
+.dynamicBackground::before {
+    width: 400px;
+    height: 400px;
+    background: radial-gradient(circle, rgba(25, 33, 72, 0.8), transparent 70%);
+    animation: move1 calc(20s / var(--bg-speed)) infinite alternate;
+}
+
+.dynamicBackground::after {
+    width: 300px;
+    height: 300px;
+    background: radial-gradient(circle, rgba(56, 33, 99, 0.6), transparent 70%);
+    animation: move2 calc(15s / var(--bg-speed)) infinite alternate;
+}
+
+.dynamicBackground[data-connection='disconnected'] {
+    background-color: #200;
+    animation: glitch 0.6s infinite;
+}
+
+.dynamicBackground[data-connection='disconnected']::before,
+.dynamicBackground[data-connection='disconnected']::after {
+    background: radial-gradient(circle, rgba(255, 0, 0, 0.6), transparent 70%);
+}
+
+@keyframes move1 {
+    0% {
+        transform: translate(10vw, 20vh) scale(1);
+    }
+    100% {
+        transform: translate(70vw, 80vh) scale(1.5);
+    }
+}
+
+@keyframes move2 {
+    0% {
+        transform: translate(80vw, 10vh) scale(1.2);
+    }
+    100% {
+        transform: translate(20vw, 60vh) scale(0.9);
+    }
+}
+
+@keyframes glitch {
+    0%, 100% {
+        transform: translate(0);
+    }
+    20% {
+        transform: translate(-5px, 5px);
+    }
+    40% {
+        transform: translate(5px, -5px);
+    }
+    60% {
+        transform: translate(-5px, -5px);
+    }
+    80% {
+        transform: translate(5px, 5px);
+    }
+}
+

--- a/packages/frontend/src/components/aura/DynamicBackground.tsx
+++ b/packages/frontend/src/components/aura/DynamicBackground.tsx
@@ -2,10 +2,28 @@
 
 import { Box } from '@mantine/core';
 import classes from './AuraLayout.module.css';
+import { useControllerStore } from '../../store/useControllerStore';
+import type { CSSProperties } from 'react';
+
+type DynamicBgStyle = CSSProperties & {
+    '--bg-speed': number;
+    '--bg-brightness': number;
+};
 
 export function DynamicBackground() {
+    const { motor, connectionStatus } = useControllerStore();
+
+    const style: DynamicBgStyle = {
+        '--bg-speed': motor.isActive ? 2 : 1,
+        '--bg-brightness': connectionStatus === 'connected' ? 0.8 : 0.4,
+    };
+
     return (
-        <Box className={classes.dynamicBackground}>
+        <Box
+            className={classes.dynamicBackground}
+            style={style}
+            data-connection={connectionStatus}
+        >
             {/* Bu boş div'ler, CSS'te ::before ve ::after ile
                 hedefleyeceğimiz katmanları temsil edecek.
                 Bu sayede daha karmaşık ve zengin bir görsel

--- a/packages/frontend/src/components/recipe/RecipeStepEditor.tsx
+++ b/packages/frontend/src/components/recipe/RecipeStepEditor.tsx
@@ -67,8 +67,11 @@ const getDefaultSettingsForMode = (mode: OperatingMode): Partial<AllModeSettings
 export function RecipeStepEditor({ step, index, totalSteps, onUpdate, onDelete, onMove }: RecipeStepEditorProps) {
 
     // Adımın ana özelliklerini (mod, süre) günceller.
-    const handleFieldChange = (field: 'mode' | 'duration', value: any) => {
-        const updatedStep = { ...step, [field]: value };
+    const handleFieldChange = (
+        field: 'mode' | 'duration',
+        value: OperatingMode | number
+    ) => {
+        const updatedStep: RecipeStep = { ...step, [field]: value };
 
         // Eğer mod değiştirildiyse, o moda ait ayarları temiz bir başlangıç için sıfırla.
         if (field === 'mode') {

--- a/packages/frontend/src/store/useControllerStore.ts
+++ b/packages/frontend/src/store/useControllerStore.ts
@@ -49,7 +49,7 @@ export interface ConsoleEntry {
     type: 'event' | 'command' | 'status';
     source: 'frontend' | 'backend';
     message: string;
-    data?: any;
+    data?: unknown;
 }
 
 // Store'daki zamanlayıcıyı tutmak için


### PR DESCRIPTION
## Summary
- tie DynamicBackground animation speed and brightness to motor activity and connection status via CSS variables
- add keyframe animations and glitch styling in AuraLayout for active/disconnected states with smooth transitions
- type CSS variables and remove remaining `any` usages to satisfy lint

## Testing
- `npm test` *(fails: Missing script "test")*
- `cd packages/frontend && npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68939698c9308320993c0870954258e3