### PR TITLE
feat: improve control arc accessibility

### DIFF
--- a/packages/frontend/src/components/aura/ControlArc.module.css
+++ b/packages/frontend/src/components/aura/ControlArc.module.css
@@ -32,7 +32,7 @@
     fill: rgba(10, 13, 26, 0.8);
     stroke: rgba(255, 255, 255, 0.2);
     stroke-width: 2px;
-    transition: stroke 0.3s ease, fill 0.3s ease;
+    transition: stroke 0.3s ease, fill 0.3s ease, filter 0.3s ease;
     backdrop-filter: blur(5px);
 }
 

--- a/packages/frontend/src/components/aura/ControlArc.module.css
+++ b/packages/frontend/src/components/aura/ControlArc.module.css
@@ -21,19 +21,24 @@
 
 .arcButton {
     cursor: pointer;
+    transition: transform 0.3s ease;
+}
+
+.arcButton.buttonActive {
+    transform: scale(1.1);
 }
 
 .buttonCircle {
     fill: rgba(10, 13, 26, 0.8);
     stroke: rgba(255, 255, 255, 0.2);
     stroke-width: 2px;
-    transition: all 0.3s ease;
+    transition: stroke 0.3s ease, fill 0.3s ease;
     backdrop-filter: blur(5px);
 }
 
 .buttonIcon {
     color: rgba(255, 255, 255, 0.5);
-    transition: all 0.3s ease;
+    transition: color 0.3s ease;
 }
 
 .arcButton:hover .buttonCircle {

--- a/packages/frontend/src/components/aura/ControlArc.tsx
+++ b/packages/frontend/src/components/aura/ControlArc.tsx
@@ -3,6 +3,7 @@
 import { Box, Text } from '@mantine/core';
 import classes from './ControlArc.module.css';
 import cx from 'clsx';
+import type React from 'react';
 import { IconInfinity, IconRepeat, IconListDetails, IconBook } from '@tabler/icons-react';
 import {useControllerStore} from "../../store/useControllerStore.ts";
 import type {OperatingMode} from "../../../../shared-types";
@@ -85,12 +86,23 @@ export function ControlArc() {
                     const { x, y } = getButtonPosition(index);
                     const Icon = mode.icon;
 
+                    const handleKeyDown = (e: React.KeyboardEvent<SVGGElement>) => {
+                        if (e.key === 'Enter' || e.key === ' ') {
+                            e.preventDefault();
+                            handleModeChange(mode.id);
+                        }
+                    };
+
                     return (
                         <g
                             key={mode.id}
                             transform={`translate(${x}, ${y})`}
-                            className={classes.arcButton}
+                            className={cx(classes.arcButton, { [classes.buttonActive]: uiMode === mode.id })}
                             onClick={() => handleModeChange(mode.id)}
+                            tabIndex={0}
+                            role="button"
+                            aria-label={mode.label}
+                            onKeyDown={handleKeyDown}
                         >
                             {/* Aktif butonu belirlemek için artık 'uiMode' kullanılıyor */}
                             <circle


### PR DESCRIPTION
## Summary
- make control arc mode buttons keyboard accessible with tabIndex and aria labels
- allow Enter and Space to switch modes
- smooth transitions and zoom for active button

## Testing
- `npm --workspace packages/frontend run lint` (fails: Unexpected any in unrelated files)
- `npm --workspace packages/frontend run build`


------
https://chatgpt.com/codex/tasks/task_e_68939889bc548320af9f0416e96919aa