### PR TITLE
feat: add feedback to holographic gauge

### DIFF
--- a/packages/frontend/src/components/aura/HolographicGauge.module.css
+++ b/packages/frontend/src/components/aura/HolographicGauge.module.css
@@ -8,6 +8,7 @@
     justify-content: center;
     align-items: center;
     --gauge-color: #00e5ff;
+    --gauge-glow: 16px;
     transition: opacity 0.3s ease; /* Opaklık geçiş efekti */
 }
 .gaugeWrapper:not(.interactive) {
@@ -34,7 +35,7 @@
 .gaugeProgress {
     stroke: var(--gauge-color);
     stroke-linecap: round;
-    filter: drop-shadow(0 0 8px var(--gauge-color)) drop-shadow(0 0 16px var(--gauge-color));
+    filter: drop-shadow(0 0 calc(var(--gauge-glow) / 2) var(--gauge-color)) drop-shadow(0 0 var(--gauge-glow) var(--gauge-color));
 }
 .gaugeTextContainer {
     position: absolute;
@@ -80,16 +81,23 @@
 
 /* İnteraktif olduğunda parlamayı daha belirgin hale getiriyoruz */
 .interactive .gaugeProgress {
-    filter: drop-shadow(0 0 18px var(--gauge-color)) drop-shadow(0 0 36px var(--gauge-color));
+    filter: drop-shadow(0 0 calc(var(--gauge-glow) * 1.1) var(--gauge-color)) drop-shadow(0 0 calc(var(--gauge-glow) * 2) var(--gauge-color));
     /* Parlamanın da nabız gibi atmasını sağlıyoruz */
     animation: pulseGlow 2s infinite ease-in-out;
 }
 
 .dragging {
+    --gauge-glow: 40px;
     user-select: none; /* Chrome, Safari, Opera */
     -webkit-user-select: none; /* Safari */
     -moz-user-select: none; /* Firefox */
     -ms-user-select: none; /* Internet Explorer/Edge */
+    filter: drop-shadow(0 0 var(--gauge-glow) var(--gauge-color)) drop-shadow(0 0 calc(var(--gauge-glow) * 1.5) var(--gauge-color));
+    transform: perspective(600px) translateZ(30px);
+}
+
+.dragging .gaugeProgress {
+    filter: drop-shadow(0 0 var(--gauge-glow) var(--gauge-color)) drop-shadow(0 0 calc(var(--gauge-glow) * 2) var(--gauge-color));
 }
 /* YENİ: Parlama için nabız animasyonu */
 @keyframes pulseGlow {

--- a/packages/frontend/src/components/aura/HolographicGauge.tsx
+++ b/packages/frontend/src/components/aura/HolographicGauge.tsx
@@ -5,6 +5,33 @@ import classes from './HolographicGauge.module.css';
 import cx from 'clsx';
 import React, {useRef, useState} from "react";
 
+// Küçük bir ses veya titreşim oluşturan geri bildirim fonksiyonu
+function playFeedback() {
+    if (typeof window === 'undefined') return;
+
+    if ('vibrate' in navigator) {
+        navigator.vibrate(10);
+    }
+
+    try {
+        const w = window as unknown as { webkitAudioContext?: typeof AudioContext };
+        const AudioCtx = window.AudioContext || w.webkitAudioContext;
+        if (!AudioCtx) return;
+        const ctx = new AudioCtx();
+        const osc = ctx.createOscillator();
+        const gain = ctx.createGain();
+        osc.type = 'sine';
+        osc.frequency.value = 880;
+        gain.gain.value = 0.05;
+        osc.connect(gain);
+        gain.connect(ctx.destination);
+        osc.start();
+        osc.stop(ctx.currentTime + 0.05);
+    } catch {
+        // Tarayıcı ses oluşturmayı engelleyebilir; sessizce başarısız ol
+    }
+}
+
 interface HolographicGaugeProps {
     value: number;
     maxValue: number;
@@ -33,12 +60,32 @@ export function HolographicGauge({ value, maxValue, label, unit, color, isIntera
         lastY.current = e.clientY;
 
         const newValue = Math.min(maxValue, Math.max(0, value + (deltaY * sensitivity)));
+        const rounded = Math.round(newValue);
 
-        onChange(Math.round(newValue));
+        if (rounded !== value) {
+            onChange(rounded);
+            playFeedback();
+        }
     };
 
     const handleMouseUp = () => {
         setIsDragging(false);
+    };
+
+    const handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+        if (!isInteractive || !onChange) return;
+        let newValue = value;
+        if (e.key === '+' || e.key === '=') {
+            newValue = Math.min(maxValue, value + 1);
+        } else if (e.key === '-' || e.key === '_') {
+            newValue = Math.max(0, value - 1);
+        } else {
+            return;
+        }
+
+        e.preventDefault();
+        onChange(newValue);
+        playFeedback();
     };
 
     const SIZE = 250;
@@ -59,6 +106,8 @@ export function HolographicGauge({ value, maxValue, label, unit, color, isIntera
             onMouseMove={handleMouseMove}
             onMouseUp={handleMouseUp}
             onMouseLeave={handleMouseUp} // Fare alandan çıkarsa da sürüklemeyi bitir
+            tabIndex={isInteractive ? 0 : undefined}
+            onKeyDown={handleKeyDown}
         >
             <svg
                 width={SIZE}


### PR DESCRIPTION
## Summary
- add playFeedback to provide audio and haptic cues
- support keyboard + / - adjustment
- enhance dragging glow with parallax effects

## Testing
- `npm run lint -w packages/frontend` *(fails: Unexpected any in RecipeStepEditor.tsx and useControllerStore.ts)*
- `npx eslint src/components/aura/HolographicGauge.tsx`
- `node - <<'NODE' ... NODE`

------
https://chatgpt.com/codex/tasks/task_e_6893988521a88320b7a7a8811032717e