### PR TITLE
feat: improve control arc accessibility

### DIFF
--- a/packages/frontend/src/components/aura/ControlArc.module.css
+++ b/packages/frontend/src/components/aura/ControlArc.module.css
@@ -27,13 +27,13 @@
     fill: rgba(10, 13, 26, 0.8);
     stroke: rgba(255, 255, 255, 0.2);
     stroke-width: 2px;
-    transition: all 0.3s ease;
+    transition: stroke 0.3s ease, fill 0.3s ease;
     backdrop-filter: blur(5px);
 }
 
 .buttonIcon {
     color: rgba(255, 255, 255, 0.5);
-    transition: all 0.3s ease;
+    transition: color 0.3s ease;
 }
 
 .arcButton:hover .buttonCircle {

--- a/packages/frontend/src/components/aura/ControlArc.tsx
+++ b/packages/frontend/src/components/aura/ControlArc.tsx
@@ -3,6 +3,7 @@
 import { Box, Text } from '@mantine/core';
 import classes from './ControlArc.module.css';
 import cx from 'clsx';
+import type React from 'react';
 import { IconInfinity, IconRepeat, IconListDetails, IconBook } from '@tabler/icons-react';
 import {useControllerStore} from "../../store/useControllerStore.ts";
 import type {OperatingMode} from "../../../../shared-types";
@@ -85,21 +86,36 @@ export function ControlArc() {
                     const { x, y } = getButtonPosition(index);
                     const Icon = mode.icon;
 
+                    const handleKeyDown = (e: React.KeyboardEvent<SVGGElement>) => {
+                        if (e.key === 'Enter' || e.key === ' ') {
+                            e.preventDefault();
+                            handleModeChange(mode.id);
+                        }
+                    };
+
+                    const isActive = uiMode === mode.id;
                     return (
                         <g
                             key={mode.id}
-                            transform={`translate(${x}, ${y})`}
-                            className={classes.arcButton}
+                            style={{
+                                transform: `translate(${x}px, ${y}px) scale(${isActive ? 1.15 : 1})`,
+                                transition: 'transform 0.3s ease',
+                                transformOrigin: 'center',
+                            }}
+                            className={cx(classes.arcButton, { [classes.buttonActive]: isActive })}
                             onClick={() => handleModeChange(mode.id)}
+                            tabIndex={0}
+                            role="button"
+                            aria-label={mode.label}
+                            onKeyDown={handleKeyDown}
                         >
-                            {/* Aktif butonu belirlemek için artık 'uiMode' kullanılıyor */}
                             <circle
                                 r="22"
-                                className={cx(classes.buttonCircle, { [classes.buttonActive]: uiMode === mode.id })}
+                                className={cx(classes.buttonCircle, { [classes.buttonActive]: isActive })}
                             />
                             <Icon
                                 size={24}
-                                className={cx(classes.buttonIcon, { [classes.buttonActive]: uiMode === mode.id })}
+                                className={cx(classes.buttonIcon, { [classes.buttonActive]: isActive })}
                                 x="-12" y="-12"
                             />
                         </g>


### PR DESCRIPTION
## Summary
- make control arc mode buttons keyboard accessible with tabIndex and aria labels
- allow Enter and Space to switch modes
- keep zoomed button centered with transform origin

## Testing
- `npm --workspace packages/frontend run lint` (fails: Unexpected any in existing files)
- `npm --workspace packages/frontend run build`


------
https://chatgpt.com/codex/tasks/task_e_68939889bc548320af9f0416e96919aa