### PR TITLE
feat: enhance recipe drawer with search and actions

### DIFF
--- a/packages/frontend/src/components/aura/RecipeDrawer.module.css
+++ b/packages/frontend/src/components/aura/RecipeDrawer.module.css
@@ -49,6 +49,38 @@
     padding-right: 15px; /* Kaydırma çubuğu için boşluk */
 }
 
+.header {
+    display: flex;
+    gap: 10px;
+    align-items: center;
+    margin-bottom: 20px;
+}
+
+.searchInput {
+    flex: 1;
+}
+
+.searchInput input {
+    background-color: rgba(255, 255, 255, 0.05);
+    border-color: rgba(255, 255, 255, 0.1);
+    color: #fff;
+}
+
+.searchInput input::placeholder {
+    color: rgba(255, 255, 255, 0.4);
+}
+
+.addButton {
+    background: linear-gradient(135deg, #00e5ff 0%, #d457ff 100%);
+    color: #fff;
+    border: none;
+    transition: background 0.2s ease;
+}
+
+.addButton:hover {
+    background: linear-gradient(135deg, #00b3cc 0%, #a43bcf 100%);
+}
+
 .recipeButton {
     display: block;
     width: 100%;
@@ -84,4 +116,13 @@
     color: #fff;
     font-weight: 500;
     text-shadow: 0 0 8px #d457ff;
+}
+
+.editIcon {
+    color: rgba(255, 255, 255, 0.6);
+    transition: color 0.2s ease;
+}
+
+.editIcon:hover {
+    color: #00e5ff;
 }

--- a/packages/frontend/src/components/aura/RecipeDrawer.module.css
+++ b/packages/frontend/src/components/aura/RecipeDrawer.module.css
@@ -4,7 +4,7 @@
     position: absolute;
     top: 0;
     right: 0;
-    width: 380px; /* Biraz daha genişletelim */
+    width: clamp(300px, 30vw, 440px);
     height: 100%;
     z-index: 20;
 
@@ -20,7 +20,7 @@
 
     display: flex;
     flex-direction: column;
-    padding: 30px 10px 30px 30px; /* İç boşlukları ayarladık */
+    padding: 30px 12px 30px 30px; /* İç boşlukları ayarladık */
 }
 
 .drawerOpen {
@@ -34,7 +34,7 @@
 }
 
 .drawerTitle {
-    font-size: 22px;
+    font-size: clamp(20px, 2vw, 26px);
     font-weight: 600;
     color: #fff;
     margin-bottom: 25px;
@@ -47,6 +47,16 @@
 .scrollArea {
     flex-grow: 1;
     padding-right: 15px; /* Kaydırma çubuğu için boşluk */
+}
+
+/* Dokunmatik ekranlarda kaydırma çubuğunu daha belirgin ve geniş hale getirelim */
+.scrollArea::-webkit-scrollbar {
+    width: 12px;
+}
+
+.scrollArea::-webkit-scrollbar-thumb {
+    background-color: rgba(0, 229, 255, 0.3);
+    border-radius: 6px;
 }
 
 .header {
@@ -64,6 +74,7 @@
     background-color: rgba(255, 255, 255, 0.05);
     border-color: rgba(255, 255, 255, 0.1);
     color: #fff;
+    font-size: clamp(14px, 1.2vw, 16px);
 }
 
 .searchInput input::placeholder {
@@ -75,6 +86,7 @@
     color: #fff;
     border: none;
     transition: background 0.2s ease;
+    font-size: clamp(14px, 1.2vw, 16px);
 }
 
 .addButton:hover {
@@ -84,17 +96,19 @@
 .recipeButton {
     display: block;
     width: 100%;
-    padding: 14px 20px;
+    padding: 16px 24px;
     border-radius: 8px; /* Daha yumuşak kenarlar */
-    margin-bottom: 10px;
+    margin-bottom: 12px;
     background-color: transparent; /* Arka planı tamamen şeffaf yapıyoruz */
     border: 1px solid rgba(255, 255, 255, 0.1); /* İnce bir çerçeve */
     transition: all 0.2s ease;
+    cursor: pointer;
 }
 
 .recipeButtonText {
     color: rgba(255, 255, 255, 0.7);
     transition: all 0.2s ease;
+    font-size: clamp(14px, 1.2vw, 18px);
 }
 
 .recipeButton:hover {

--- a/packages/frontend/src/components/aura/RecipeDrawer.tsx
+++ b/packages/frontend/src/components/aura/RecipeDrawer.tsx
@@ -1,6 +1,8 @@
 // packages/frontend/src/components/aura/RecipeDrawer.tsx (GÜNCELLENMİŞ HALİ)
 
-import { Box, ScrollArea, Text, UnstyledButton } from '@mantine/core';
+import { ActionIcon, Box, Button, Group, ScrollArea, Text, TextInput, UnstyledButton } from '@mantine/core';
+import { IconEdit, IconPlus } from '@tabler/icons-react';
+import { useMemo, useState } from 'react';
 import { useControllerStore } from '../../store/useControllerStore';
 import classes from './RecipeDrawer.module.css';
 import cx from 'clsx';
@@ -9,13 +11,25 @@ import { NotificationService } from '../../services/notificationService';
 
 export function RecipeDrawer() {
     const { isRecipeDrawerOpen, savedRecipes, activeRecipe, setActiveRecipe, toggleRecipeDrawer } = useControllerStore();
+    const [search, setSearch] = useState('');
 
-    // Fonksiyonun adı aynı kalabilir, ama artık çift tıklama ile tetiklenecek
+    const filteredRecipes = useMemo(
+        () => savedRecipes.filter(r => r.name.toLowerCase().includes(search.toLowerCase())),
+        [savedRecipes, search]
+    );
+
     const handleActivateRecipe = (recipe: Recipe) => {
         setActiveRecipe(recipe);
         NotificationService.showSuccess(`'${recipe.name}' aktif reçete olarak ayarlandı.`);
-        // Reçete seçildiğinde paneli kapat
         toggleRecipeDrawer(false);
+    };
+
+    const handleCreateRecipe = () => {
+        NotificationService.showInfo('Reçete editörü yakında eklenecek.');
+    };
+
+    const handleEditRecipe = (recipe: Recipe) => {
+        NotificationService.showInfo(`'${recipe.name}' için düzenleme yakında eklenecek.`);
     };
 
     return (
@@ -30,19 +44,45 @@ export function RecipeDrawer() {
         >
             <Box className={classes.drawerContent}>
                 <Text className={classes.drawerTitle}>Kütüphane</Text>
+                <Group className={classes.header} gap="sm">
+                    <TextInput
+                        value={search}
+                        onChange={(e) => setSearch(e.currentTarget.value)}
+                        placeholder="Reçetelerde ara..."
+                        className={classes.searchInput}
+                        size="xs"
+                    />
+                    <Button
+                        leftSection={<IconPlus size={16} />}
+                        onClick={handleCreateRecipe}
+                        className={classes.addButton}
+                        size="xs"
+                    >
+                        Yeni
+                    </Button>
+                </Group>
 
                 <ScrollArea className={classes.scrollArea}>
-                    {savedRecipes.length === 0 ? (
+                    {filteredRecipes.length === 0 ? (
                         <Text c="dimmed" ta="center" pt="xl">Kayıtlı reçete bulunamadı.</Text>
                     ) : (
-                        savedRecipes.map(recipe => (
+                        filteredRecipes.map(recipe => (
                             <UnstyledButton
                                 key={recipe.id}
                                 className={cx(classes.recipeButton, { [classes.activeRecipe]: recipe.id === activeRecipe?.id })}
-                                // onClick -> onDoubleClick olarak değiştirildi
                                 onDoubleClick={() => handleActivateRecipe(recipe)}
                             >
-                                <Text size="sm" className={classes.recipeButtonText}>{recipe.name}</Text>
+                                <Group justify="space-between">
+                                    <Text size="sm" className={classes.recipeButtonText}>{recipe.name}</Text>
+                                    <ActionIcon
+                                        size="sm"
+                                        variant="subtle"
+                                        className={classes.editIcon}
+                                        onClick={(e) => { e.stopPropagation(); handleEditRecipe(recipe); }}
+                                    >
+                                        <IconEdit size={14} />
+                                    </ActionIcon>
+                                </Group>
                             </UnstyledButton>
                         ))
                     )}

--- a/packages/frontend/src/components/aura/RecipeDrawer.tsx
+++ b/packages/frontend/src/components/aura/RecipeDrawer.tsx
@@ -50,13 +50,13 @@ export function RecipeDrawer() {
                         onChange={(e) => setSearch(e.currentTarget.value)}
                         placeholder="Reçetelerde ara..."
                         className={classes.searchInput}
-                        size="xs"
+                        size="sm"
                     />
                     <Button
-                        leftSection={<IconPlus size={16} />}
+                        leftSection={<IconPlus size={20} />}
                         onClick={handleCreateRecipe}
                         className={classes.addButton}
-                        size="xs"
+                        size="sm"
                     >
                         Yeni
                     </Button>
@@ -70,25 +70,26 @@ export function RecipeDrawer() {
                             <UnstyledButton
                                 key={recipe.id}
                                 className={cx(classes.recipeButton, { [classes.activeRecipe]: recipe.id === activeRecipe?.id })}
-                                onDoubleClick={() => handleActivateRecipe(recipe)}
+                                onClick={() => handleActivateRecipe(recipe)}
                             >
-                                <Group justify="space-between">
-                                    <Text size="sm" className={classes.recipeButtonText}>{recipe.name}</Text>
+                                <Group justify="space-between" align="center">
+                                    <Text className={classes.recipeButtonText}>{recipe.name}</Text>
                                     <ActionIcon
-                                        size="sm"
+                                        size="md"
                                         variant="subtle"
                                         className={classes.editIcon}
                                         onClick={(e) => { e.stopPropagation(); handleEditRecipe(recipe); }}
+                                        aria-label="Reçeteyi düzenle"
                                     >
-                                        <IconEdit size={14} />
+                                        <IconEdit size={18} />
                                     </ActionIcon>
                                 </Group>
                             </UnstyledButton>
                         ))
                     )}
                 </ScrollArea>
-                <Text c="dimmed" fz="xs" ta="center" mt="md">
-                    Aktif etmek için bir reçeteye çift tıklayın.
+                <Text c="dimmed" fz="sm" ta="center" mt="md">
+                    Aktif etmek için bir reçeteye dokunun.
                 </Text>
             </Box>
         </Box>

--- a/packages/frontend/src/services/notificationService.tsx
+++ b/packages/frontend/src/services/notificationService.tsx
@@ -1,7 +1,7 @@
 // packages/frontend/src/services/notificationService.tsx
 
 import { notifications } from '@mantine/notifications';
-import { IconCheck, IconX } from '@tabler/icons-react';
+import { IconCheck, IconInfoCircle, IconX } from '@tabler/icons-react';
 
 /**
  * Başarı bildirimini gösterir.
@@ -33,8 +33,24 @@ const showError = (message: string) => {
     });
 };
 
+/**
+ * Bilgi amaçlı bildirim gösterir.
+ * @param message - Bildirimde gösterilecek mesaj.
+ */
+const showInfo = (message: string) => {
+    notifications.show({
+        title: 'Bilgi',
+        message,
+        color: 'blue',
+        icon: <IconInfoCircle size={18} />,
+        withCloseButton: true,
+        autoClose: 3000,
+    });
+};
+
 // Fonksiyonları tek bir nesne altında export ederek daha temiz bir kullanım sağlıyoruz.
 export const NotificationService = {
     showSuccess,
     showError,
+    showInfo,
 };


### PR DESCRIPTION
## Summary
- add search and new-recipe button to RecipeDrawer
- expose edit action and notifications for upcoming recipe editor
- extend NotificationService with informational messages

## Testing
- `npm test` (package frontend: missing script)
- `npm run lint`
- `npm test` (root: missing script)


------
https://chatgpt.com/codex/tasks/task_e_6893ae0036e083208bd05cec9ee76a1e